### PR TITLE
Remove dict.keys() when not need it

### DIFF
--- a/perprof/prof.py
+++ b/perprof/prof.py
@@ -78,8 +78,8 @@ class Pdata:
             self.number_problems
         except:
             p = set()
-            for i in self.data.keys():
-                for j in self.data[i].keys():
+            for i in self.data:
+                for j in self.data[i]:
                     p.add(j)
             self.problems = p
             self.number_problems = len(p)


### PR DESCRIPTION
In a for loop over a dictionary we don't need to use the `keys`
methods.
