### PR TITLE
Add option to limit the x-axis range

### DIFF
--- a/perprof/main.py
+++ b/perprof/main.py
@@ -10,6 +10,7 @@ class PerProfSetup():
         self.bw = args.black_and_white
         self.output = args.output
         self.subset = args.subset
+        self.tau = args.tau
 
         if args.pdf:
             self.output_format = 'pdf'
@@ -66,6 +67,12 @@ class PerProfSetup():
     def set_subset(self, subset):
         self.subset = subset
 
+    def get_tau(self):
+        return self.tau
+
+    def set_tau(self, tau):
+        self.tau = tau
+
 def main():
     """This is the entry point when calling perprof."""
     import argparse
@@ -97,6 +104,8 @@ def main():
             help='Enable cache.')
     parser.add_argument('-s', '--subset',
             help='Name of a file with a subset of problems to compare')
+    parser.add_argument('--tau', type=float,
+            help='Limit the x-axis based this value')
     parser.add_argument('-f', '--force', action='store_true',
             help='Force overwrite the output file')
     parser.add_argument('-o', '--output',

--- a/perprof/prof.py
+++ b/perprof/prof.py
@@ -32,6 +32,7 @@ class Pdata:
         self.semilog = setup.using_semilog()
         self.bw = setup.using_black_and_white()
         self.output_format = setup.get_output_format()
+        self.tau = setup.get_tau()
 
     def __repr__(self):
         try:

--- a/perprof/tikz.py
+++ b/perprof/tikz.py
@@ -46,6 +46,7 @@ class Profiler(prof.Pdata):
             self.set_percent_problems_solved_by_time()
 
         maxt = max(self.times)
+        maxt = min(maxt, self.tau)
 
         str2output = ''
 
@@ -79,9 +80,10 @@ class Profiler(prof.Pdata):
         for s in self.solvers:
             str2output += '  \\addplot+[mark=none, thick] coordinates {\n'
             for i in range(len(self.times)):
-                t = self.times[i]
-                p = self.ppsbt[s][i]
-                str2output += '    ({:.4f},{:.4f})\n'.format(t,p)
+                if self.times[i] < self.tau:
+                    t = self.times[i]
+                    p = self.ppsbt[s][i]
+                    str2output += '    ({:.4f},{:.4f})\n'.format(t,p)
             str2output += '  };\n'
             str2output += '  \\addlegendentry{' + s + '}\n'
         if self.semilog:


### PR DESCRIPTION
In most cases you won't the information for high performance
ratio because no one like to wait more than 100 times of the best
solver time.
- Add option `--tau`
- Change TikZ backend for use the new option

NOTE: This is just a hack. There must be a better way of doing this.
