### PR TITLE
Add option to pgfplot compatibility

### DIFF
--- a/perprof/main.py
+++ b/perprof/main.py
@@ -10,6 +10,7 @@ class PerProfSetup():
         self.bw = args.black_and_white
         self.output = args.output
         self.subset = args.subset
+        self.pgfplot_version = args.pgfplotcompat
 
         if args.pdf:
             self.output_format = 'pdf'
@@ -66,6 +67,12 @@ class PerProfSetup():
     def set_subset(self, subset):
         self.subset = subset
 
+    def get_pgfplot_version(self):
+        return self.pgfplot_version
+
+    def set_pgfplot_version(self, version):
+        self.pgfplot_version = version
+
 def main():
     """This is the entry point when calling perprof."""
     import argparse
@@ -93,6 +100,8 @@ def main():
             help='Use logarithmic scale for the x axis of the plot.')
     parser.add_argument('--tikz-header', action='store_true',
             help='Create the header to the tikz file, enabling compilation of the result')
+    parser.add_argument('--pgfplotcompat', type=float, default=None,
+            help='Set pgfplots backwards compatibility mode to given version')
     parser.add_argument('-c', '--cache', action='store_true',
             help='Enable cache.')
     parser.add_argument('-s', '--subset',

--- a/perprof/prof.py
+++ b/perprof/prof.py
@@ -32,6 +32,7 @@ class Pdata:
         self.semilog = setup.using_semilog()
         self.bw = setup.using_black_and_white()
         self.output_format = setup.get_output_format()
+        self.pgfplot_version = setup.get_pgfplot_version()
 
     def __repr__(self):
         try:

--- a/perprof/tikz.py
+++ b/perprof/tikz.py
@@ -55,7 +55,12 @@ class Profiler(prof.Pdata):
             str2output += '\\usepackage[T1]{fontenc}\n'
             str2output += '\\usepackage{tikz}\n'
             str2output += '\\usepackage{pgfplots}\n'
-            str2output += '\\pgfplotsset{compat=1.9}\n'
+            if self.pgfplot_version is not None:
+                str2output += '\\pgfplotsset{{compat={0}}}\n'.format(
+                        self.pgfplot_version)
+            else:
+                str2output += '\\pgfplotsset{compat=newest,compat/show ' \
+                        'suggested version=false}\n'
             str2output += '\\begin{document}\n'
         else:
             str2output += '\\begin{center}\n'


### PR DESCRIPTION
@abelsiqueira request low the value of pgfplot compatibility option.
Low the value is not the best solution due it is dependent of the
installation.

To solve the problem we add a new option in the command line. If the
user don't use it perprof-py will be compatible with the newer version.

A brief explanation about this solution can be found at
http://tex.stackexchange.com/a/81912/22451.
