### PR TITLE
Add flag for translation of axis label

### DIFF
--- a/perprof/main.py
+++ b/perprof/main.py
@@ -3,6 +3,7 @@
 class PerProfSetup():
     """This is a class to store the files to be used."""
     def __init__(self, args):
+        self.lang = args.lang
         self.free_format = args.free_format
         self.cache = args.cache
         self.files = args.file_name
@@ -22,6 +23,12 @@ class PerProfSetup():
             self.output_format = 'tex'
         else:
             self.output_format = None
+
+    def using_lang(self):
+        return self.lang
+
+    def set_lang(self, lang):
+        self.lang = lang
 
     def using_free_format(self):
         return self.free_format
@@ -123,6 +130,8 @@ def main():
     output_format.add_argument('--pdf', action='store_true',
             help='The output file will be a PDF file')
 
+    parser.add_argument('-l', '--lang', choices=['en', 'pt_BR'], default='en',
+            help='Set language for axis label')
     parser.add_argument('--free-format', action='store_true',
             help='When parsing file handle all non `c` character as `d`')
     parser.add_argument('--pdf-verbose', action='store_true',

--- a/perprof/tikz.py
+++ b/perprof/tikz.py
@@ -25,6 +25,11 @@ class Profiler(prof.Pdata):
         prof.Pdata.__init__(self, setup)
         self.output_format = setup.get_output_format()
 
+        # Language for the axis label
+        t = gettext.translation('perprof', os.path.join(this_dir,
+            'locale'), [setup.lang])
+        self.axis_lang = t.gettext
+
     def scale(self):
         self.already_scaled = True
         super().scale()
@@ -90,8 +95,9 @@ class Profiler(prof.Pdata):
         '    xlabel={{{xlabel}}}, ylabel={{{ylabel}}},\n' \
         '    legend pos= south east,\n' \
         '    width=\\textwidth\n' \
-        '    ]\n'.format(maxt, xlabel=_('Performance Ratio'),
-                ylabel=_('Problems solved'))
+        '    ]\n'.format(maxt,
+                xlabel=self.axis_lang('Performance Ratio'),
+                ylabel=self.axis_lang('Problems solved'))
 
         for s in self.solvers:
             str2output += '  \\addplot+[mark=none, thick] coordinates {\n'


### PR DESCRIPTION
Related with PR #40.

Add flat `--lang` to select the language of the axis labels. The
language of the label can be different from the system language.

**Note**: No option to user defined label will be provided right
now.

**Note**: Probably this not work with Windows.
